### PR TITLE
feat: refill draw deck with shuffled toss deck

### DIFF
--- a/UnoGame/Card/CardManager.cpp
+++ b/UnoGame/Card/CardManager.cpp
@@ -87,6 +87,17 @@ void CardManager::RemoveCardFromDrawDeck()
 
 CardBehaviour CardManager::PopNextCardFromDrawDeck()
 {
+    if (static_cast<int>(_drawDeck.size()) <= 0)
+    {
+        while (!_tossDeck.empty())
+        {
+            _drawDeck.emplace_back(_tossDeck.top());
+            _tossDeck.pop();
+        }
+        
+        ShuffleCards();
+    }
+    
     const CardBehaviour selectedCard = _drawDeck.back();
     _drawDeck.pop_back();
     return selectedCard;

--- a/UnoGame/Card/CardManager.h
+++ b/UnoGame/Card/CardManager.h
@@ -26,7 +26,7 @@ private:
     std::stack<CardBehaviour> _tossDeck;
 
     int _initialDeckSize = 104;
-    int _initialHandSize = 7; // 7
+    int _initialHandSize = 1; // 7
     
     int _amountOfReverseCardsPerColor = 2;
     int _amountOfPlusTwoCardsPerColor = 2;


### PR DESCRIPTION
### CHANGES
- Added a check before draw a card from draw deck
- If there isn't cards on draw deck, it takes de toss deck, put the cards in the draw deck and shuffle them so the player can buy a card again